### PR TITLE
Allow use without activerecord

### DIFF
--- a/lib/resque_delay/message_sending.rb
+++ b/lib/resque_delay/message_sending.rb
@@ -4,7 +4,7 @@ module ResqueDelay
     def initialize(target, options)
       @target = target
       @options = options
-      if @options[:in].not_nil? && !@options[:in].kind_of?(::Fixnum)
+      if @options[:in].present? && !@options[:in].kind_of?(::Fixnum)
         raise ::ArgumentError.new("Delayed settings must be a Fixnum! not a #{@options[:in].class.name}") 
       end
     end
@@ -21,7 +21,11 @@ module ResqueDelay
 
     # Called asynchrously by Resque
     def self.perform(args)
-      PerformableMethod.new(*args).perform
+      if args.respond_to?(:[])
+        PerformableMethod.new(args["object"], args["method"], args["args"])
+      else
+        PerformableMethod.new(*args).perform
+      end
     end
 
     private

--- a/lib/resque_delay/performable_method.rb
+++ b/lib/resque_delay/performable_method.rb
@@ -4,7 +4,7 @@ module ResqueDelay
     AR_STRING_FORMAT    = /^AR\:([A-Z][\w\:]+)\:(\d+)$/
 
     def self.create(object, method, args)
-      raise NoMethodError, "undefined method `#{method}' for #{object.inspect}" unless object.respond_to?(method)
+      raise NoMethodError, "undefined method `#{method}' for #{object.inspect}" unless object.respond_to?(method, true)
       self.new(object, method, args)
     end
 

--- a/resque-delay.gemspec
+++ b/resque-delay.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("spec/**/*")
 
   s.add_dependency    "resque", ">= 1.9"
-  s.add_dependency    "activerecord", ">= 2.3"
 
   s.description = <<DESCRIPTION
 Enable send_later support for Resque


### PR DESCRIPTION
This allows resque-delay to be used in environments without activerecord loaded.

Also, a change in Ruby 2.0 caused `respond_to?` to only check public methods. Occasionally, an instance may delay its own private methods, in these cases.. `respond_to?` fails and requires the second argument to check all methods.